### PR TITLE
feat: display bible search results

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,8 @@ function AppInner() {
   }
 
   const slides = playlist.map(s => ({ ...s, _next: next, _prev: prev }));
+  const showingSearch = search.query.trim().length > 0;
+  const versesToShow = showingSearch ? search.results : verses;
 
   return (
     <div className="min-h-screen bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-100 transition-colors">
@@ -106,7 +108,12 @@ function AppInner() {
           </div>
 
           <div className="space-y-6">
-            <VersesList verses={verses} onAddVerse={addVerseToPlaylist} />
+            <VersesList
+              verses={versesToShow}
+              title={showingSearch ? "Resultados de búsqueda" : "Versículos"}
+              error={showingSearch ? search.error : null}
+              onAddVerse={addVerseToPlaylist}
+            />
             <PlaylistPanel
               playlist={playlist}
               currentIndex={currentIndex}

--- a/src/features/bible/components/VersesList.jsx
+++ b/src/features/bible/components/VersesList.jsx
@@ -2,17 +2,38 @@ import React from "react";
 import Card from "../../../components/ui/Card";
 import Button from "../../../components/ui/Button";
 
-export default function VersesList({ verses, onAddVerse }) {
+export default function VersesList({
+  verses,
+  onAddVerse,
+  title = "Versículos",
+  error = null,
+}) {
   return (
     <Card className="p-6">
-      <h3 className="font-medium mb-3 text-gray-900 dark:text-gray-100">Versículos</h3>
+      <h3 className="font-medium mb-3 text-gray-900 dark:text-gray-100">{title}</h3>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-red-700 dark:text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+
       <div className="max-h-96 overflow-y-auto space-y-2">
-        {verses.map(verse => (
-          <div key={verse.id} className="flex items-center justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
-            <span className="text-sm font-medium text-blue-600 dark:text-blue-400">{verse.reference}</span>
-            <Button size="sm" variant="outline" onClick={() => onAddVerse(verse)}>Añadir</Button>
-          </div>
-        ))}
+        {verses.length === 0 ? (
+          <p className="text-sm text-gray-500 dark:text-gray-400">No hay resultados</p>
+        ) : (
+          verses.map(verse => (
+            <div key={verse.id} className="flex items-start justify-between p-3 bg-gray-50 dark:bg-gray-800 rounded-lg">
+              <div className="mr-2">
+                <span className="text-sm font-medium text-blue-600 dark:text-blue-400">{verse.reference}</span>
+                {(verse.text || verse.content) && (
+                  <div className="text-xs text-gray-600 dark:text-gray-400 mt-1" dangerouslySetInnerHTML={{ __html: verse.text || verse.content }} />
+                )}
+              </div>
+              <Button size="sm" variant="outline" onClick={() => onAddVerse(verse)}>Añadir</Button>
+            </div>
+          ))
+        )}
       </div>
     </Card>
   );

--- a/src/features/bible/hooks/useSearch.jsx
+++ b/src/features/bible/hooks/useSearch.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { searchPassages } from "../../../api/bible";
 
 export default function useSearch(bibleId) {
@@ -6,6 +6,13 @@ export default function useSearch(bibleId) {
   const [searching, setSearching] = useState(false);
   const [results, setResults] = useState([]);
   const [error, setError] = useState(null);
+
+  useEffect(() => {
+    if (!query) {
+      setResults([]);
+      setError(null);
+    }
+  }, [query]);
 
   async function doSearch(e) {
     e?.preventDefault?.();


### PR DESCRIPTION
## Summary
- clear bible search results when query changes
- show results and errors in verse list
- surface search results in main app

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ce44e1c3c833099affcd682bbd398