### PR TITLE
feat: integrate svg icons for modern UI

### DIFF
--- a/src/features/bible/components/Controls.jsx
+++ b/src/features/bible/components/Controls.jsx
@@ -4,6 +4,7 @@ import Select from "../../../components/ui/Select";
 import Input from "../../../components/ui/Input";
 import Button from "../../../components/ui/Button";
 import Spinner from "../../../components/ui/Spinner";
+import { Search } from "lucide-react";
 
 export default function Controls({
   bibles, bibleId, setBibleId,
@@ -37,7 +38,14 @@ export default function Controls({
           theme={theme}
         />
         <Button onClick={doSearch} disabled={searching} theme={theme}>
-          {searching ? <Spinner /> : "Buscar"}
+          {searching ? (
+            <Spinner />
+          ) : (
+            <>
+              <Search className="w-4 h-4 mr-1" />
+              Buscar
+            </>
+          )}
         </Button>
       </div>
     </Card>

--- a/src/features/bible/components/PlaylistPanel.jsx
+++ b/src/features/bible/components/PlaylistPanel.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Card from "../../../components/ui/Card";
 import Button from "../../../components/ui/Button";
+import { Play, Trash2, ArrowRight, X } from "lucide-react";
 
 export default function PlaylistPanel({
   playlist,
@@ -18,8 +19,12 @@ export default function PlaylistPanel({
       <div className="flex items-center justify-between mb-4">
         <h3 className={`font-medium ${isDark ? 'text-gray-100' : 'text-gray-900'}`}>Playlist ({playlist.length})</h3>
         <div className="flex gap-2">
-          <Button size="sm" onClick={onStart} disabled={playlist.length === 0} theme={theme}>▶</Button>
-          <Button size="sm" variant="outline" onClick={onClear} theme={theme}>🗑</Button>
+          <Button size="sm" onClick={onStart} disabled={playlist.length === 0} theme={theme}>
+            <Play className="w-4 h-4" />
+          </Button>
+          <Button size="sm" variant="outline" onClick={onClear} theme={theme}>
+            <Trash2 className="w-4 h-4" />
+          </Button>
         </div>
       </div>
 
@@ -49,13 +54,13 @@ export default function PlaylistPanel({
                     onClick={() => setCurrentIndex(i)}
                     className={`text-xs px-2 py-1 rounded ${isDark ? 'bg-gray-700 hover:bg-gray-600' : 'bg-gray-100 hover:bg-gray-200'}`}
                   >
-                    Ir
+                    <ArrowRight className="w-3 h-3" />
                   </button>
                   <button
                     onClick={() => onRemove(slide.id)}
                     className={`text-xs px-2 py-1 rounded text-red-600 ${isDark ? 'hover:bg-red-900/20' : 'hover:bg-red-50'}`}
                   >
-                    ×
+                    <X className="w-3 h-3" />
                   </button>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- replace text labels with lucide-react icons in search and playlist controls
- import lucide icons for play, trash, arrow, and search actions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.js)

------
https://chatgpt.com/codex/tasks/task_e_689d11b5cc98833089babbcead1a3c22