### PR TITLE
Add playlist panel and grid selection

### DIFF
--- a/src/features/bible/components/VersesGrid.jsx
+++ b/src/features/bible/components/VersesGrid.jsx
@@ -2,9 +2,9 @@
 import React from "react";
 import Card from "../../../components/ui/Card";
 
-export default function VersesGrid({ verses, onSelect, title = "Versículos", theme = "light" }) {
+export default function VersesGrid({ verses, onAdd, title = "Versículos", theme = "light" }) {
   const isDark = theme === "dark";
-  
+
   return (
     <Card className="p-4 h-[calc(100vh-8rem)]" theme={theme}>
       <h3 className={`font-medium mb-2 ${isDark ? 'text-gray-200' : 'text-gray-800'}`}>
@@ -14,10 +14,10 @@ export default function VersesGrid({ verses, onSelect, title = "Versículos", th
         {verses.map((v, idx) => (
           <button
             key={v.id || idx}
-            onClick={() => onSelect(v, idx)}
+            onClick={() => onAdd && onAdd(v, idx)}
             className={`p-2 text-left rounded-lg border transition-colors duration-150 ${
-              isDark 
-                ? 'bg-gray-800 border-gray-700 hover:bg-blue-900 text-gray-200' 
+              isDark
+                ? 'bg-gray-800 border-gray-700 hover:bg-blue-900 text-gray-200'
                 : 'bg-white border-gray-200 hover:bg-blue-50 text-gray-800 shadow-sm hover:shadow-md'
             }`}
           >
@@ -25,7 +25,7 @@ export default function VersesGrid({ verses, onSelect, title = "Versículos", th
               {v.reference}
             </span>
             {(v.text || v.content) && (
-              <span 
+              <span
                 className={`block mt-1 text-xs ${isDark ? 'text-gray-400' : 'text-gray-600'}`}
                 dangerouslySetInnerHTML={{ __html: v.text || v.content }}
               />


### PR DESCRIPTION
## Summary
- integrate PlaylistPanel alongside verses and chapters
- allow adding verses from grid into playlist

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689d1350b1e083308569b2dc1a894a2c