### PR TITLE
Add SVG icons to header, chapters and verses

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import ChaptersList from "./features/bible/components/ChaptersList";
 import VersesGrid from "./features/bible/components/VersesGrid";
 import PlaylistPanel from "./features/bible/components/PlaylistPanel";
 import Button from "./components/ui/Button";
+import { BookOpen } from "lucide-react";
 import { getVerseHtml } from "./features/bible/api/bible"; //
 
 function AppInner() {
@@ -71,7 +72,12 @@ function AppInner() {
     <div className={`min-h-screen ${theme === "dark" ? "bg-gray-950 text-white" : "bg-gray-50 text-gray-900"}`}>
       <div className="max-w-7xl mx-auto px-4 py-6">
         <header className="text-center mb-8">
-          <h1 className={`text-3xl font-light tracking-tight mb-2 ${theme === "dark" ? "text-white" : "text-gray-900"}`}>
+          <h1
+            className={`text-3xl font-light tracking-tight mb-2 flex items-center justify-center gap-2 ${
+              theme === "dark" ? "text-white" : "text-gray-900"
+            }`}
+          >
+            <BookOpen className="w-8 h-8" />
             Bible Presenter
           </h1>
           <p className={`font-light ${theme === "dark" ? "text-gray-400" : "text-gray-600"}`}>

--- a/src/features/bible/components/ChaptersList.jsx
+++ b/src/features/bible/components/ChaptersList.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import Card from "../../../components/ui/Card";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, List } from "lucide-react";
 
 export default function ChaptersList({ chapters, currentId, onSelect, theme = "light" }) {
   const [currentPage, setCurrentPage] = useState(0);
@@ -33,7 +33,10 @@ export default function ChaptersList({ chapters, currentId, onSelect, theme = "l
   return (
     <Card className="p-4" theme={theme}>
       <div className="flex items-center justify-between mb-2">
-        <h3 className={`font-medium ${isDark ? 'text-gray-100' : 'text-gray-900'}`}>Capítulos</h3>
+        <h3 className={`font-medium flex items-center gap-2 ${isDark ? 'text-gray-100' : 'text-gray-900'}`}>
+          <List className="w-4 h-4" />
+          Capítulos
+        </h3>
         {totalPages > 1 && (
           <div className="flex items-center gap-2">
             <button

--- a/src/features/bible/components/VersesGrid.jsx
+++ b/src/features/bible/components/VersesGrid.jsx
@@ -1,13 +1,15 @@
 // features/bible/components/VersesGrid.jsx
 import React from "react";
 import Card from "../../../components/ui/Card";
+import { Hash } from "lucide-react";
 
 export default function VersesGrid({ verses, onAdd, title = "Versículos", theme = "light" }) {
   const isDark = theme === "dark";
 
   return (
     <Card className="p-4 h-[calc(100vh-8rem)]" theme={theme}>
-      <h3 className={`font-medium mb-2 ${isDark ? 'text-gray-200' : 'text-gray-800'}`}>
+      <h3 className={`font-medium mb-2 flex items-center gap-2 ${isDark ? 'text-gray-200' : 'text-gray-800'}`}>
+        <Hash className="w-4 h-4" />
         {title}
       </h3>
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 h-[calc(100vh-13rem)] overflow-y-auto">

--- a/src/features/bible/components/VersesList.jsx
+++ b/src/features/bible/components/VersesList.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import Card from "../../../components/ui/Card";
 import Button from "../../../components/ui/Button";
+import { Hash } from "lucide-react";
 
 export default function VersesList({
   verses,
@@ -13,7 +14,8 @@ export default function VersesList({
   
   return (
     <Card className="p-6" theme={theme}>
-      <h3 className={`font-medium mb-3 ${isDark ? 'text-gray-100' : 'text-gray-900'}`}>
+      <h3 className={`font-medium mb-3 flex items-center gap-2 ${isDark ? 'text-gray-100' : 'text-gray-900'}`}>
+        <Hash className="w-4 h-4" />
         {title}
       </h3>
 


### PR DESCRIPTION
## Summary
- add book icon to app header
- show list icon beside capítulos heading
- show hash icon beside versículos titles

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.* file)


------
https://chatgpt.com/codex/tasks/task_e_689d153d19148330b5a6f890e4ac07b9