### PR TITLE
Detectar referencias bíblicas y fondo con imagen de iglesia

### DIFF
--- a/public/church.svg
+++ b/public/church.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="30" y="40" width="40" height="50" fill="#ddd" stroke="#555" />
+  <polygon points="50,20 20,40 80,40" fill="#ccc" stroke="#555" />
+  <rect x="46" y="50" width="8" height="40" fill="#999" />
+  <rect x="47" y="10" width="6" height="20" fill="#555" />
+  <rect x="40" y="10" width="20" height="6" fill="#555" />
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,6 +39,7 @@ function AppInner() {
 
   const showingSearch = search.query.trim().length > 0;
   const versesToShow = showingSearch ? search.results : verses;
+  const isSearchReference = showingSearch && search.isReference;
 
   const stripTags = (s = "") => s.replace(/<[^>]*>/g, " ").replace(/\s+/g, " ").trim();
 
@@ -170,6 +171,7 @@ function AppInner() {
                     title={showingSearch ? "Resultados de búsqueda" : "Versículos"}
                     onAdd={handleAddVerse}
                     theme={theme}
+                    isReference={isSearchReference}
                   />
                 )
               ) : (

--- a/src/components/presenter/Presenter.jsx
+++ b/src/components/presenter/Presenter.jsx
@@ -41,11 +41,20 @@ export default function Presenter({ open, onClose, slides, index, theme, showRef
   const hasText = typeof slide.text === "string" && slide.text.trim() !== "";
 
   return (
-    <div ref={ref} className="fixed inset-0 z-50 bg-black">
+    <div ref={ref} className="fixed inset-0 z-50">
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: "url('/church.svg')" }}
+      />
+      <div
+        className={`absolute inset-0 ${
+          theme === "light" ? "bg-white/80" : "bg-black/80"
+        }`}
+      />
       <div id="blackout" className="hidden absolute inset-0 bg-black" />
       <div
-        className={`h-full w-full flex flex-col items-center justify-center px-12 py-8 ${
-          theme === "light" ? "bg-white text-black" : "bg-black text-white"
+        className={`relative h-full w-full flex flex-col items-center justify-center px-12 py-8 ${
+          theme === "light" ? "text-black" : "text-white"
         }`}
       >
         <div className="max-w-6xl w-full text-center">

--- a/src/features/bible/components/VersesGrid.jsx
+++ b/src/features/bible/components/VersesGrid.jsx
@@ -3,8 +3,9 @@ import React from "react";
 import Card from "../../../components/ui/Card";
 import { Hash } from "lucide-react";
 
-export default function VersesGrid({ verses, onAdd, title = "Versículos", theme = "light" }) {
+export default function VersesGrid({ verses, onAdd, title = "Versículos", theme = "light", isReference = false }) {
   const isDark = theme === "dark";
+  const cols = isReference ? "grid-cols-1" : "grid-cols-2 sm:grid-cols-3 md:grid-cols-4";
 
   return (
     <Card className="p-4 h-auto" theme={theme}>
@@ -12,7 +13,7 @@ export default function VersesGrid({ verses, onAdd, title = "Versículos", theme
         <Hash className="w-4 h-4" />
         {title}
       </h3>
-      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-2 h-auto overflow-y-auto ">
+      <div className={`grid ${cols} gap-2 h-auto overflow-y-auto`}>
         {verses.map((v, idx) => (
           <button
             key={v.id || idx}

--- a/src/features/bible/hooks/useSearch.jsx
+++ b/src/features/bible/hooks/useSearch.jsx
@@ -6,6 +6,7 @@ export default function useSearch(bibleId) {
   const [searching, setSearching] = useState(false);
   const [results, setResults] = useState([]);
   const [error, setError] = useState(null);
+  const [isReference, setIsReference] = useState(false);
 
   useEffect(() => {
     if (!query) {
@@ -16,15 +17,19 @@ export default function useSearch(bibleId) {
 
   async function doSearch(e) {
     e?.preventDefault?.();
-    if (!bibleId || !query.trim()) return;
+    const q = query.trim();
+    if (!bibleId || !q) return;
+    const refPattern = /^([1-3]?\s?[A-Za-zÁÉÍÓÚÑáéíóúñ]+)\s+\d+(?::\d+(?:-\d+)?)?$/i;
+    const isRef = refPattern.test(q);
+    setIsReference(isRef);
     try {
       setSearching(true); setError(null);
-      const data = await searchPassages(bibleId, query, 30);
+      const data = await searchPassages(bibleId, q, 30);
       const d = data?.data || {};
       setResults(d.passages || d.verses || []);
     } catch (e2) { setError(e2.message); }
     finally { setSearching(false); }
   }
 
-  return { query, setQuery, searching, results, error, doSearch };
+  return { query, setQuery, searching, results, error, isReference, doSearch };
 }


### PR DESCRIPTION
## Summary
- Detecta si la búsqueda corresponde a una referencia bíblica
- Muestra los resultados de búsquedas no bíblicas en varias columnas
- Presentador con imagen de iglesia como fondo

## Testing
- `npm test` *(falla: Missing script: "test")*
- `npm run lint` *(falla: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689d69b32d6c8330a57f49a1c9f05fd9