### PR TITLE
Toggle presenter text with B key

### DIFF
--- a/src/components/presenter/Presenter.jsx
+++ b/src/components/presenter/Presenter.jsx
@@ -1,8 +1,9 @@
 // components/presenter/Presenter.jsx
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 export default function Presenter({ open, onClose, slides, index, theme, showRef }) {
   const ref = useRef(null);
+  const [showImage, setShowImage] = useState(false);
 
   useEffect(() => {
     if (!open) return;
@@ -23,8 +24,7 @@ export default function Presenter({ open, onClose, slides, index, theme, showRef
         document.getElementById("prevSlide")?.click();
       } else if (e.key.toLowerCase() === "b") {
         e.preventDefault();
-        const blackout = document.getElementById("blackout");
-        if (blackout) blackout.classList.toggle("hidden");
+        setShowImage((prev) => !prev);
       } else if (e.key === "Escape") {
         e.preventDefault();
         onClose();
@@ -46,52 +46,55 @@ export default function Presenter({ open, onClose, slides, index, theme, showRef
         className="absolute inset-0 bg-cover bg-center"
         style={{ backgroundImage: "url('/church.svg')" }}
       />
-      <div
-        className={`absolute inset-0 ${
-          theme === "light" ? "bg-white/80" : "bg-black/80"
-        }`}
-      />
-      <div id="blackout" className="hidden absolute inset-0 bg-black" />
-      <div
-        className={`relative h-full w-full flex flex-col items-center justify-center px-12 py-8 ${
-          theme === "light" ? "text-black" : "text-white"
-        }`}
-      >
-        <div className="max-w-6xl w-full text-center">
-          {showRef && slide.reference && (
-            <div className="text-3xl font-light opacity-80 mb-8 tracking-wide">
-              {slide.reference}
-            </div>
-          )}
-
+      {!showImage && (
+        <>
           <div
-            id="presenter-content"
-            className="text-4xl md:text-5xl lg:text-6xl font-light leading-tight tracking-wide"
-            style={{ lineHeight: "1.4" }}
+            className={`absolute inset-0 ${
+              theme === "light" ? "bg-white/80" : "bg-black/80"
+            }`}
+          />
+          <div
+            className={`relative h-full w-full flex flex-col items-center justify-center px-12 py-8 ${
+              theme === "light" ? "text-black" : "text-white"
+            }`}
           >
-            {hasHtml ? (
-              <div dangerouslySetInnerHTML={{ __html: slide.html }} className="max-w-[100vw]" />
-            ) : hasText ? (
-              slide.html
-            ) : (
-              <span className="opacity-60 text-2xl">Sin contenido</span>
-            )}
+            <div className="max-w-6xl w-full text-center">
+              {showRef && slide.reference && (
+                <div className="text-3xl font-light opacity-80 mb-8 tracking-wide">
+                  {slide.reference}
+                </div>
+              )}
+
+              <div
+                id="presenter-content"
+                className="text-4xl md:text-5xl lg:text-6xl font-light leading-tight tracking-wide"
+                style={{ lineHeight: "1.4" }}
+              >
+                {hasHtml ? (
+                  <div dangerouslySetInnerHTML={{ __html: slide.html }} className="max-w-[100vw]" />
+                ) : hasText ? (
+                  slide.html
+                ) : (
+                  <span className="opacity-60 text-2xl">Sin contenido</span>
+                )}
+              </div>
+            </div>
+
+            <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-4
+                            bg-black/20 backdrop-blur-sm rounded-full px-6 py-3 text-sm opacity-70 hover:opacity-100 transition-opacity">
+              <button id="prevSlide" onClick={() => slide._prev?.()} className="p-2 hover:bg-white/20 rounded-full">← Anterior</button>
+              <span className="px-4 py-1 bg-white/10 rounded-full">{index + 1} / {slides.length}</span>
+              <button id="nextSlide" onClick={() => slide._next?.()} className="p-2 hover:bg-white/20 rounded-full">Siguiente →</button>
+              <div className="w-px h-6 bg-white/30" />
+              <button onClick={onClose} className="p-2 hover:bg-white/20 rounded-full">Salir</button>
+            </div>
+
+            <div className="absolute top-4 right-4 text-xs opacity-50">
+              ← → Espacio | B (Ocultar texto) | Esc (Salir)
+            </div>
           </div>
-        </div>
-
-        <div className="absolute bottom-8 left-1/2 -translate-x-1/2 flex items-center gap-4 
-                        bg-black/20 backdrop-blur-sm rounded-full px-6 py-3 text-sm opacity-70 hover:opacity-100 transition-opacity">
-          <button id="prevSlide" onClick={() => slide._prev?.()} className="p-2 hover:bg-white/20 rounded-full">← Anterior</button>
-          <span className="px-4 py-1 bg-white/10 rounded-full">{index + 1} / {slides.length}</span>
-          <button id="nextSlide" onClick={() => slide._next?.()} className="p-2 hover:bg-white/20 rounded-full">Siguiente →</button>
-          <div className="w-px h-6 bg-white/30" />
-          <button onClick={onClose} className="p-2 hover:bg-white/20 rounded-full">Salir</button>
-        </div>
-
-        <div className="absolute top-4 right-4 text-xs opacity-50">
-          ← → Espacio | B (Blackout) | Esc (Salir)
-        </div>
-      </div>
+        </>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add state to presenter for toggling text visibility with the `B` key
- Show full-screen church image when text is hidden
- Update on-screen hint to reflect new `B` behavior

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689d6c7cd0b083308e9d75d27a5f062b