### PR TITLE
feat: add cuadrangular color palette

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -99,28 +99,26 @@ function AppInner() {
   }
 
   return (
-    <div className={`min-h-screen grid grid-cols-1 ${theme === "dark" ? "bg-gray-950 text-white" : "bg-gray-50 text-gray-900 grid"}`}>
-      <div className="max-w-7xl mx-auto px-4 py-6">
-        <header className="text-center mb-8">
-          <h1
-            className={`text-3xl font-light tracking-tight mb-2 flex items-center justify-center gap-2 ${
-              theme === "dark" ? "text-white" : "text-gray-900"
-            }`}
-          >
-            <BookOpen className="w-8 h-8" />
-            Bible Presenter
-          </h1>
-          <p className={`font-light ${theme === "dark" ? "text-gray-400" : "text-gray-600"}`}>
-            Presentaciones modernas para iglesias
-          </p>
-        </header>
-        <div className="flex items-center justify-end gap-2 mb-6">
-          <span className={`text-sm ${theme === "dark" ? "text-gray-400" : "text-gray-600"}`}>Tema:</span>
-          <Button
-            variant={theme === "dark" ? "primary" : "outline"}
-            size="sm"
-            onClick={() => setTheme("dark")}
-            theme={theme}
+      <div className={`min-h-screen grid grid-cols-1 ${theme === "dark" ? "bg-gray-950 text-white" : "bg-gray-50 text-gray-900 grid"}`}>
+        <div className="max-w-7xl mx-auto px-4 py-6">
+          <header className="text-center mb-8">
+            <h1
+              className="text-3xl font-light tracking-tight mb-2 flex items-center justify-center gap-2 text-icc-purple"
+            >
+              <BookOpen className="w-8 h-8 text-icc-orange" />
+              Bible Presenter
+            </h1>
+            <p className="font-light text-icc-orange">
+              Presentaciones modernas para iglesias
+            </p>
+          </header>
+          <div className="flex items-center justify-end gap-2 mb-6">
+            <span className="text-sm text-icc-yellow">Tema:</span>
+            <Button
+              variant={theme === "dark" ? "primary" : "outline"}
+              size="sm"
+              onClick={() => setTheme("dark")}
+              theme={theme}
           >
             Oscuro
           </Button>
@@ -144,17 +142,17 @@ function AppInner() {
           theme={theme}
         />
 
-        <div className="flex items-center justify-end gap-4 mb-6">
-          <label className={`flex items-center gap-2 text-sm ${theme === "dark" ? "text-gray-400" : "text-gray-600"}`}>
-            <input
-              type="checkbox"
-              checked={showRef}
-              onChange={(e) => setShowRef(e.target.checked)}
-              className={`rounded ${theme === "dark" ? "border-gray-600" : "border-gray-300"}`}
-            />
-            Mostrar referencia
-          </label>
-        </div>
+          <div className="flex items-center justify-end gap-4 mb-6">
+            <label className="flex items-center gap-2 text-sm text-icc-orange">
+              <input
+                type="checkbox"
+                checked={showRef}
+                onChange={(e) => setShowRef(e.target.checked)}
+                className={`rounded ${theme === "dark" ? "border-gray-600" : "border-gray-300"}`}
+              />
+              Mostrar referencia
+            </label>
+          </div>
         {bookId && (
           <div className="grid grid-cols-1 md:grid-cols-5 gap-6 order-3 md:order-2">
             <div className="md:col-span-3">
@@ -162,7 +160,7 @@ function AppInner() {
                 loading ? (
                   <p className={`text-sm ${theme === "dark" ? "text-gray-400" : "text-gray-600"}`}>Cargando...</p>
                 ) : error ? (
-                  <p className={`text-sm ${theme === "dark" ? "text-red-400" : "text-red-600"}`}>{error}</p>
+                    <p className={`text-sm ${theme === "dark" ? "text-icc-red" : "text-icc-red"}`}>{error}</p>
                 ) : (
                   <VersesGrid
                     verses={versesToShow}

--- a/src/components/ui/Button.jsx
+++ b/src/components/ui/Button.jsx
@@ -1,45 +1,46 @@
 import React from "react";
 
 export default function Button({
-  children, 
-  variant = "primary", 
-  size = "md", 
-  onClick, 
-  disabled, 
-  className = "", 
+  children,
+  variant = "primary",
+  size = "md",
+  onClick,
+  disabled,
+  className = "",
   theme = "light",
   ...props
 }) {
   const isDark = theme === "dark";
-  
-  const baseStyles = "rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
-  
+
+  const baseStyles =
+    "rounded-lg font-medium transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed";
+
   const variants = {
-    primary: isDark 
-      ? "bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-500 focus:ring-offset-gray-900"
-      : "bg-blue-600 hover:bg-blue-700 text-white focus:ring-blue-500 focus:ring-offset-white shadow-sm",
-      
+    primary: isDark
+      ? "bg-icc-purple hover:bg-icc-purple/90 text-white focus:ring-icc-purple focus:ring-offset-gray-900"
+      : "bg-icc-blue hover:bg-icc-blue/90 text-white focus:ring-icc-blue focus:ring-offset-white shadow-sm",
+
     secondary: isDark
-      ? "bg-gray-800 hover:bg-gray-700 text-gray-100 focus:ring-gray-500 focus:ring-offset-gray-900"
-      : "bg-gray-100 hover:bg-gray-200 text-gray-900 focus:ring-gray-300 focus:ring-offset-white shadow-sm",
-      
+      ? "bg-icc-blue hover:bg-icc-blue/90 text-white focus:ring-icc-blue focus:ring-offset-gray-900"
+      : "bg-icc-purple hover:bg-icc-purple/90 text-white focus:ring-icc-purple focus:ring-offset-white shadow-sm",
+
     outline: isDark
-      ? "border border-gray-600 hover:bg-gray-800 text-gray-100 focus:ring-gray-500 focus:ring-offset-gray-900"
-      : "border border-gray-300 hover:bg-gray-50 text-gray-700 focus:ring-gray-200 focus:ring-offset-white",
-      
+      ? "border border-icc-blue hover:bg-icc-blue/20 text-gray-100 focus:ring-icc-blue focus:ring-offset-gray-900"
+      : "border border-icc-blue hover:bg-icc-blue/10 text-gray-700 focus:ring-icc-blue focus:ring-offset-white",
+
     ghost: isDark
-      ? "hover:bg-gray-800 text-gray-100 focus:ring-gray-500 focus:ring-offset-gray-900"
-      : "hover:bg-gray-100 text-gray-700 focus:ring-gray-200 focus:ring-offset-white",
-      
+      ? "hover:bg-icc-blue/20 text-gray-100 focus:ring-icc-blue focus:ring-offset-gray-900"
+      : "hover:bg-icc-blue/10 text-gray-700 focus:ring-icc-blue focus:ring-offset-white",
+
     danger: isDark
-      ? "bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 focus:ring-offset-gray-900"
-      : "bg-red-600 hover:bg-red-700 text-white focus:ring-red-500 focus:ring-offset-white shadow-sm"
+      ? "bg-icc-red hover:bg-icc-red/90 text-white focus:ring-icc-red focus:ring-offset-gray-900"
+      : "bg-icc-red hover:bg-icc-red/90 text-white focus:ring-icc-red focus:ring-offset-white shadow-sm",
   };
 
-  const sizes = { 
-    sm: "px-3 py-1.5 text-xs", 
-    md: "px-4 py-2 text-sm", 
-    lg: "px-6 py-3 text-base" 
+  const sizes = {
+    sm: "px-3 py-1.5 text-xs",
+    md: "px-4 py-2 text-sm",
+    lg: "px-6 py-3 text-base",
   };
 
   return (
@@ -53,3 +54,4 @@ export default function Button({
     </button>
   );
 }
+

--- a/src/components/ui/Input.jsx
+++ b/src/components/ui/Input.jsx
@@ -14,8 +14,8 @@ export default function Input({ label, className = "", theme = "light", ...props
         {...props}
         className={`w-full px-3 py-2 rounded-lg border focus:outline-none focus:ring-2 focus:border-transparent ${
           isDark
-            ? "border-gray-600 bg-gray-800 text-gray-100 placeholder:text-gray-500 focus:ring-blue-500"
-            : "border-gray-300 bg-white text-gray-900 placeholder:text-gray-400 focus:ring-blue-500 shadow-sm"
+            ? "border-gray-600 bg-gray-800 text-gray-100 placeholder:text-gray-500 focus:ring-icc-blue"
+            : "border-gray-300 bg-white text-gray-900 placeholder:text-gray-400 focus:ring-icc-blue shadow-sm"
         } ${className}`}
       />
     </div>

--- a/src/components/ui/Select.jsx
+++ b/src/components/ui/Select.jsx
@@ -14,8 +14,8 @@ export default function Select({ label, children, className = "", theme = "light
         {...props}
         className={`w-full px-3 py-2 rounded-lg border focus:outline-none focus:ring-2 focus:border-transparent ${
           isDark
-            ? "border-gray-600 bg-gray-800 text-gray-100 focus:ring-blue-500"
-            : "border-gray-300 bg-white text-gray-900 focus:ring-blue-500 shadow-sm"
+            ? "border-gray-600 bg-gray-800 text-gray-100 focus:ring-icc-blue"
+            : "border-gray-300 bg-white text-gray-900 focus:ring-icc-blue shadow-sm"
         } ${className}`}
       >
         {children}

--- a/src/components/ui/Spinner.jsx
+++ b/src/components/ui/Spinner.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Spinner() {
     return (
-      <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
+      <div className="animate-spin h-4 w-4 border-2 border-icc-blue border-t-transparent rounded-full" />
     );
   }
   

--- a/src/features/bible/components/ChapterView.jsx
+++ b/src/features/bible/components/ChapterView.jsx
@@ -12,7 +12,7 @@ export default function ChapterView({ title, chapterHtml, onAddChapter, loading,
         {loading && (
           <div className={`flex items-center gap-2 text-sm ${isDark ? 'text-gray-400' : 'text-gray-500'}`}>
             <span>Cargando…</span>
-            <div className="animate-spin h-4 w-4 border-2 border-blue-500 border-t-transparent rounded-full" />
+            <div className="animate-spin h-4 w-4 border-2 border-icc-blue border-t-transparent rounded-full" />
           </div>
         )}
       </div>
@@ -20,8 +20,8 @@ export default function ChapterView({ title, chapterHtml, onAddChapter, loading,
       {error && (
         <div className={`mb-4 p-3 rounded-lg text-sm border ${
           isDark
-            ? 'bg-red-900/20 border-red-800 text-red-300'
-            : 'bg-red-50 border-red-200 text-red-700'
+            ? 'bg-icc-red/20 border-icc-red text-icc-red'
+            : 'bg-icc-red/10 border-icc-red/50 text-icc-red'
         }`}>
           {error}
         </div>

--- a/src/features/bible/components/ChaptersList.jsx
+++ b/src/features/bible/components/ChaptersList.jsx
@@ -69,7 +69,7 @@ export default function ChaptersList({ chapters, currentId, onSelect, theme = "l
             onClick={() => onSelect(ch.id)}
             className={`w-full text-left px-4 py-3 rounded-lg transition-colors ${
               ch.id === currentId
-                ? 'bg-blue-600 text-white'
+                ? 'bg-icc-blue text-white'
                 : isDark
                   ? 'bg-gray-800 hover:bg-gray-700 text-gray-200'
                   : 'bg-gray-100 hover:bg-gray-200 text-gray-800'

--- a/src/features/bible/components/PlaylistPanel.jsx
+++ b/src/features/bible/components/PlaylistPanel.jsx
@@ -40,15 +40,15 @@ export default function PlaylistPanel({
               className={`p-3 rounded-lg border transition-colors ${
                 i === currentIndex
                   ? isDark
-                    ? 'border-blue-500 bg-blue-900/20'
-                    : 'border-blue-500 bg-blue-50'
+                    ? 'border-icc-blue bg-icc-blue/20'
+                    : 'border-icc-blue bg-icc-blue/10'
                   : isDark
                     ? 'border-gray-700 hover:bg-gray-800'
                     : 'border-gray-200 hover:bg-gray-50'
-              }`}
+            }`}
             >
               <div className="flex items-center justify-between mb-2">
-                <span className={`text-xs font-medium ${isDark ? 'text-blue-400' : 'text-blue-600'}`}>{slide.reference}</span>
+                <span className={`text-xs font-medium ${isDark ? 'text-icc-blue' : 'text-icc-blue'}`}>{slide.reference}</span>
                 <div className="flex gap-1">
                   <button
                     onClick={() => setCurrentIndex(i)}
@@ -58,7 +58,7 @@ export default function PlaylistPanel({
                   </button>
                   <button
                     onClick={() => onRemove(slide.id)}
-                    className={`text-xs px-2 py-1 rounded text-red-600 ${isDark ? 'hover:bg-red-900/20' : 'hover:bg-red-50'}`}
+                    className={`text-xs px-2 py-1 rounded text-icc-red ${isDark ? 'hover:bg-icc-red/20' : 'hover:bg-icc-red/10'}`}
                   >
                     <X className="w-3 h-3" />
                   </button>

--- a/src/features/bible/components/VersesGrid.jsx
+++ b/src/features/bible/components/VersesGrid.jsx
@@ -20,11 +20,11 @@ export default function VersesGrid({ verses, onAdd, title = "Versículos", theme
             onClick={() => onAdd && onAdd(v, idx)}
             className={`p-2 text-left rounded-lg border transition-colors duration-150 ${
               isDark
-                ? 'bg-gray-800 border-gray-700 hover:bg-blue-900 text-gray-200'
-                : 'bg-white border-gray-200 hover:bg-blue-50 text-gray-800 shadow-sm hover:shadow-md'
+                ? 'bg-gray-800 border-gray-700 hover:bg-icc-blue/30 text-gray-200'
+                : 'bg-white border-gray-200 hover:bg-icc-blue/10 text-gray-800 shadow-sm hover:shadow-md'
             }`}
           >
-            <span className={`block font-medium ${isDark ? 'text-blue-400' : 'text-blue-600'}`}>
+            <span className={`block font-medium ${isDark ? 'text-icc-blue' : 'text-icc-blue'}`}>
               {v.reference}
             </span>
             {(v.text || v.content) && (

--- a/src/features/bible/components/VersesList.jsx
+++ b/src/features/bible/components/VersesList.jsx
@@ -21,9 +21,9 @@ export default function VersesList({
 
       {error && (
         <div className={`mb-4 p-3 rounded-lg text-sm ${
-          isDark 
-            ? 'bg-red-900/20 border-red-800 text-red-300' 
-            : 'bg-red-50 border-red-200 text-red-700'
+          isDark
+            ? 'bg-icc-red/20 border-icc-red text-icc-red'
+            : 'bg-icc-red/10 border-icc-red/50 text-icc-red'
         } border`}>
           {error}
         </div>
@@ -44,7 +44,7 @@ export default function VersesList({
             >
               <div className="mr-2 flex-1">
                 <span className={`text-sm font-medium ${
-                  isDark ? 'text-blue-400' : 'text-blue-600'
+                  isDark ? 'text-icc-blue' : 'text-icc-blue'
                 }`}>
                   {verse.reference}
                 </span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,13 @@ export default {
   ],
   theme: {
     extend: {
+        colors: {
+            'icc-purple': '#483473',
+            'icc-blue': '#0367A6',
+            'icc-yellow': '#F2B705',
+            'icc-orange': '#F29F05',
+            'icc-red': '#D92929',
+        },
         backdropBlur: {
             xs: '2px',
         },


### PR DESCRIPTION
## Summary
- add Iglesia Cristiana Cuadrangular color tokens to Tailwind
- theme buttons, labels and verse lists with new palette

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68a2213dfe948330a25c272aa6d7429a