### PR TITLE
Abrir la presentación de texto biblico en otra pestaña

### DIFF
--- a/src/features/bible/api/client.jsx
+++ b/src/features/bible/api/client.jsx
@@ -1,8 +1,7 @@
 import React from "react";
 
 const API_BASE = "https://api.scripture.api.bible/v1";
-const API_KEY =
-  (typeof process !== "undefined" && process.env?.VITE_API_BIBLE_KEY)
+const API_KEY = import.meta.env.VITE_API_BIBLE_KEY;
 
 export async function api(path, params = {}) {
   const url = new URL(API_BASE + path);


### PR DESCRIPTION
@codex corrige que ahora la presentación del versiculo no se está proyectando ni en la misma pestaña ni en otra, quiero que se presente en una nueva pestaña o ventana