### PR TITLE
Render presenter in separate window

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -49,6 +49,13 @@ function AppInner() {
     const win = window.open("", "_blank", "noopener,noreferrer");
     if (!win) return;
     win.document.title = "Bible Presenter";
+
+    // Copy styles from the main document so Tailwind classes render correctly
+    const styleNodes = document.head.querySelectorAll("style,link[rel='stylesheet']");
+    styleNodes.forEach((node) => {
+      win.document.head.appendChild(node.cloneNode(true));
+    });
+
     const el = win.document.createElement("div");
     win.document.body.appendChild(el);
     const root = createRoot(el);
@@ -67,6 +74,7 @@ function AppInner() {
         index={currentIndex}
         theme={theme}
         showRef={showRef}
+        targetWindow={win}
       />
     );
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -74,7 +82,7 @@ function AppInner() {
 
   useEffect(() => {
     if (!presenterRef.current) return;
-    const { root, close } = presenterRef.current;
+    const { root, close, win } = presenterRef.current;
     root.render(
       <Presenter
         open
@@ -83,6 +91,7 @@ function AppInner() {
         index={currentIndex}
         theme={theme}
         showRef={showRef}
+        targetWindow={win}
       />
     );
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/presenter/Presenter.jsx
+++ b/src/components/presenter/Presenter.jsx
@@ -1,27 +1,40 @@
 // components/presenter/Presenter.jsx
 import React, { useEffect, useRef, useState } from "react";
 
-export default function Presenter({ open, onClose, slides, index, theme, showRef }) {
+// Allow rendering inside a different window (e.g. presenter tab)
+export default function Presenter({
+  open,
+  onClose,
+  slides,
+  index,
+  theme,
+  showRef,
+  targetWindow = window,
+}) {
   const ref = useRef(null);
   const [showImage, setShowImage] = useState(false);
 
+  // Request fullscreen on the element inside the target window
   useEffect(() => {
     if (!open) return;
     const el = ref.current;
-    if (el && !document.fullscreenElement) {
+    const doc = targetWindow.document;
+    if (el && doc && !doc.fullscreenElement) {
       el.requestFullscreen?.().catch(() => {});
     }
-  }, [open]);
+  }, [open, targetWindow]);
 
+  // Keyboard navigation should listen on the presenter window
   useEffect(() => {
     const onKey = (e) => {
       if (!open) return;
+      const doc = targetWindow.document;
       if (["ArrowRight", "PageDown", "Space"].includes(e.key)) {
         e.preventDefault();
-        document.getElementById("nextSlide")?.click();
+        doc.getElementById("nextSlide")?.click();
       } else if (["ArrowLeft", "PageUp"].includes(e.key)) {
         e.preventDefault();
-        document.getElementById("prevSlide")?.click();
+        doc.getElementById("prevSlide")?.click();
       } else if (e.key.toLowerCase() === "b") {
         e.preventDefault();
         setShowImage((prev) => !prev);
@@ -30,9 +43,9 @@ export default function Presenter({ open, onClose, slides, index, theme, showRef
         onClose();
       }
     };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
+    targetWindow.addEventListener("keydown", onKey);
+    return () => targetWindow.removeEventListener("keydown", onKey);
+  }, [open, onClose, targetWindow]);
 
   if (!open) return null;
 

--- a/src/store/PlaylistContext.jsx
+++ b/src/store/PlaylistContext.jsx
@@ -1,4 +1,11 @@
-import React, { createContext, useContext, useMemo, useReducer, useState } from "react";
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  useReducer,
+  useState,
+  useCallback,
+} from "react";
 
 const Ctx = createContext(null);
 
@@ -29,21 +36,36 @@ export function PlaylistProvider({ children }) {
   const [theme, setTheme] = useState("dark");
   const [showRef, setShowRef] = useState(true);
 
-  const next = () => setCurrentIndex(i => Math.min(i + 1, playlist.length - 1));
-  const prev = () => setCurrentIndex(i => Math.max(i - 1, 0));
+  const next = useCallback(
+    () => setCurrentIndex((i) => Math.min(i + 1, playlist.length - 1)),
+    [playlist.length]
+  );
+  const prev = useCallback(
+    () => setCurrentIndex((i) => Math.max(i - 1, 0)),
+    []
+  );
 
-  const value = useMemo(() => ({
-    playlist, dispatch,
-    presenting, setPresenting,
-    currentIndex, setCurrentIndex,
-    theme, setTheme,
-    showRef, setShowRef,
-    next, prev
-  }), [playlist, presenting, currentIndex, theme, showRef]);
+  const value = useMemo(
+    () => ({
+      playlist,
+      dispatch,
+      presenting,
+      setPresenting,
+      currentIndex,
+      setCurrentIndex,
+      theme,
+      setTheme,
+      showRef,
+      setShowRef,
+      next,
+      prev,
+    }),
+    [playlist, presenting, currentIndex, theme, showRef, next, prev]
+  );
 
   return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
 }
-
+// eslint-disable-next-line react-refresh/only-export-components
 export const usePlaylist = () => {
   const ctx = useContext(Ctx);
   if (!ctx) throw new Error("usePlaylist must be used within PlaylistProvider");


### PR DESCRIPTION
## Summary
- open verses presenter in a dedicated window with copied styles
- handle keyboard events and fullscreen in the new window
- stabilize playlist context helpers

## Testing
- `cp eslint.config.jsx eslint.config.js && npx eslint src && echo 'lint ok' && rm eslint.config.js`


------
https://chatgpt.com/codex/tasks/task_e_68af953419c48330adeb64dacdef23e1